### PR TITLE
ioRedis  Cluster Options support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "redis-smq-common",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "redis-smq-common",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@redis/client": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-smq-common",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "RedisSMQ shared components that may be used by integrated applications and extensions.",
   "author": "Weyoss <weyoss@protonmail.com>",
   "license": "MIT",

--- a/src/redis-client/clients/ioredis-client-multi.ts
+++ b/src/redis-client/clients/ioredis-client-multi.ts
@@ -1,12 +1,12 @@
 import { ICallback, IRedisClientMulti } from '../../../types';
 import { RedisClientError } from '../errors/redis-client.error';
-import { Pipeline, Redis } from 'ioredis';
+import { Cluster, Pipeline, Redis } from 'ioredis';
 import { WatchedKeysChangedError } from '../errors/watched-keys-changed.error';
 
 export class IoredisClientMulti implements IRedisClientMulti {
   protected multi: Pipeline;
 
-  constructor(client: Redis) {
+  constructor(client: Redis | Cluster) {
     this.multi = client.multi();
   }
 

--- a/src/redis-client/clients/ioredis-client.ts
+++ b/src/redis-client/clients/ioredis-client.ts
@@ -1,16 +1,29 @@
 import { RedisClient } from '../redis-client';
-import { Redis, RedisOptions } from 'ioredis';
+import {
+  Cluster,
+  ClusterNode,
+  ClusterOptions,
+  Redis,
+  RedisOptions,
+} from 'ioredis';
 import { ICallback } from '../../../types';
 import { RedisClientError } from '../errors/redis-client.error';
 import * as IORedis from 'ioredis';
 import { IoredisClientMulti } from './ioredis-client-multi';
 
 export class IoredisClient extends RedisClient {
-  protected client: Redis;
+  protected client: Redis | Cluster;
 
-  constructor(config: RedisOptions = {}) {
+  constructor(
+    config: RedisOptions | ClusterOptions = {},
+    startupNodes?: ClusterNode[],
+  ) {
     super();
-    this.client = new IORedis(config);
+    if (startupNodes && startupNodes.length > 0) {
+      this.client = new IORedis.Cluster(startupNodes, config);
+    } else {
+      this.client = new IORedis(config);
+    }
     this.client.once('ready', () => {
       this.connectionClosed = false;
       this.emit('ready');

--- a/src/redis-client/create-client-instance.ts
+++ b/src/redis-client/create-client-instance.ts
@@ -12,7 +12,7 @@ function getClient(config: TRedisConfig) {
   if (config.client === RedisClientName.REDIS_V4) {
     return new NodeRedisV4Client(config.options);
   }
-  return new IoredisClient(config.options);
+  return new IoredisClient(config.options, config.startupNodes);
 }
 
 export function createClientInstance(

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,4 +1,4 @@
-import { RedisOptions } from 'ioredis';
+import { ClusterNode, ClusterOptions, RedisOptions } from 'ioredis';
 import { Callback, ClientOpts } from 'redis';
 import * as Logger from 'bunyan';
 import { RedisClientMultiCommandType } from '@redis/client/dist/lib/client/multi-command';
@@ -12,7 +12,8 @@ import {
 
 export interface IORedisConfig {
   client: RedisClientName.IOREDIS;
-  options?: RedisOptions;
+  options?: RedisOptions | ClusterOptions;
+  startupNodes?: ClusterNode[];
 }
 
 export enum RedisClientName {


### PR DESCRIPTION
This PR provides an alternative option to pass the config parameters to create **an ioredis instance** using a **Redis cluster**
This was tested on aws elasticache cluster:

```typescript
export const QueueBaseConfig: IConfig = {
  namespace: 'base-queue',
  redis: {
    client: 'ioredis' as any,
    options: {
    showFriendlyErrorStack: true,
    dnsLookup: (address, callback) => callback(null, address),
    scaleReads: 'all',
    redisOptions: {
      connectionName: 'Scheduling-api',
      showFriendlyErrorStack: true,
      enableAutoPipelining: true,
      tls: {
        checkServerIdentity: (/*host, cert*/) => {
          // skip certificate hostname validation
          return undefined;
        },
      },
    },
  };,
    startupNodes:  [
  {
    host: 'redis.database.local',
    port: 6379,
  },
],
  },

  logger: {
    enabled: true,
    options: {
      level: 'debug',
    },
  },
  messages: {
    store: false,
  },
};
```

